### PR TITLE
PHP8.4 support. PHP Deprecated: Implicitly marking parameter as nulla…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.2.4"
+        "php": ">=7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7|~4.0|~5.0",

--- a/src/Mustache/Engine.php
+++ b/src/Mustache/Engine.php
@@ -741,7 +741,7 @@ class Mustache_Engine
      *
      * @return Mustache_Template
      */
-    private function loadSource($source, Mustache_Cache $cache = null)
+    private function loadSource($source, ?Mustache_Cache $cache = null)
     {
         $className = $this->getTemplateClassName($source);
 

--- a/src/Mustache/Exception/SyntaxException.php
+++ b/src/Mustache/Exception/SyntaxException.php
@@ -21,7 +21,7 @@ class Mustache_Exception_SyntaxException extends LogicException implements Musta
      * @param array     $token
      * @param Exception $previous
      */
-    public function __construct($msg, array $token, Exception $previous = null)
+    public function __construct($msg, array $token, ?Exception $previous = null)
     {
         $this->token = $token;
         if (version_compare(PHP_VERSION, '5.3.0', '>=')) {

--- a/src/Mustache/Exception/UnknownFilterException.php
+++ b/src/Mustache/Exception/UnknownFilterException.php
@@ -20,7 +20,7 @@ class Mustache_Exception_UnknownFilterException extends UnexpectedValueException
      * @param string    $filterName
      * @param Exception $previous
      */
-    public function __construct($filterName, Exception $previous = null)
+    public function __construct($filterName, ?Exception $previous = null)
     {
         $this->filterName = $filterName;
         $message = sprintf('Unknown filter: %s', $filterName);

--- a/src/Mustache/Exception/UnknownHelperException.php
+++ b/src/Mustache/Exception/UnknownHelperException.php
@@ -20,7 +20,7 @@ class Mustache_Exception_UnknownHelperException extends InvalidArgumentException
      * @param string    $helperName
      * @param Exception $previous
      */
-    public function __construct($helperName, Exception $previous = null)
+    public function __construct($helperName, ?Exception $previous = null)
     {
         $this->helperName = $helperName;
         $message = sprintf('Unknown helper: %s', $helperName);

--- a/src/Mustache/Exception/UnknownTemplateException.php
+++ b/src/Mustache/Exception/UnknownTemplateException.php
@@ -20,7 +20,7 @@ class Mustache_Exception_UnknownTemplateException extends InvalidArgumentExcepti
      * @param string    $templateName
      * @param Exception $previous
      */
-    public function __construct($templateName, Exception $previous = null)
+    public function __construct($templateName, ?Exception $previous = null)
     {
         $this->templateName = $templateName;
         $message = sprintf('Unknown template: %s', $templateName);

--- a/src/Mustache/Parser.php
+++ b/src/Mustache/Parser.php
@@ -72,7 +72,7 @@ class Mustache_Parser
      *
      * @return array Mustache Token parse tree
      */
-    private function buildTree(array &$tokens, array $parent = null)
+    private function buildTree(array &$tokens, ?array $parent = null)
     {
         $nodes = array();
 


### PR DESCRIPTION
…ble is deprecated, the explicit nullable type must be used instead